### PR TITLE
ByteArrayExt impl

### DIFF
--- a/packages/bytes/src/byte_array_ext.cairo
+++ b/packages/bytes/src/byte_array_ext.cairo
@@ -1,0 +1,325 @@
+use alexandria_math::{U128BitShift, U256BitShift};
+use core::num::traits::Zero;
+use starknet::ContractAddress;
+
+/// Extension trait for reading and writing different data types to `ByteArray`
+pub trait ByteArrayTraitExt {
+    /// Reads a 16-bit unsigned integer from the given offset.
+    fn read_u16(self: @ByteArray, offset: usize) -> (usize, u16);
+    /// Reads a 32-bit unsigned integer from the given offset.
+    fn read_u32(self: @ByteArray, offset: usize) -> (usize, u32);
+    /// Reads a `usize` (platform-dependent size) integer from the given offset.
+    fn read_usize(self: @ByteArray, offset: usize) -> (usize, usize);
+    /// Reads a 64-bit unsigned integer from the given offset.
+    fn read_u64(self: @ByteArray, offset: usize) -> (usize, u64);
+    /// Reads a 128-bit unsigned integer from the given offset.
+    fn read_u128(self: @ByteArray, offset: usize) -> (usize, u128);
+    /// Reads a packed array of `u128` values from the given offset.
+    fn read_u128_array_packed(
+        self: @ByteArray, offset: usize, array_length: usize, element_size: usize,
+    ) -> (usize, Array<u128>);
+    /// Reads a 256-bit unsigned integer from the given offset.
+    fn read_u256(self: @ByteArray, offset: usize) -> (usize, u256);
+    /// Reads an array of `u256` values from the given offset.
+    fn read_u256_array(
+        self: @ByteArray, offset: usize, array_length: usize,
+    ) -> (usize, Array<u256>);
+    /// Reads a `felt252` (Starknet field element) from the given offset.
+    fn read_felt252(self: @ByteArray, offset: usize) -> (usize, felt252);
+    /// Reads a `bytes31` value (31-byte sequence) from the given offset.
+    fn read_bytes31(self: @ByteArray, offset: usize) -> (usize, bytes31);
+    /// Reads a Starknet contract address from the given offset.
+    fn read_address(self: @ByteArray, offset: usize) -> (usize, ContractAddress);
+    /// Reads a raw sequence of bytes of given `size` from the given offset.
+    fn read_bytes(self: @ByteArray, offset: usize, size: usize) -> (usize, ByteArray);
+    /// Appends a 16-bit unsigned integer to the `ByteArray`.
+    fn append_u16(ref self: ByteArray, value: u16);
+    /// Appends a 32-bit unsigned integer to the `ByteArray`.
+    fn append_u32(ref self: ByteArray, value: u32);
+    /// Appends a 64-bit unsigned integer to the `ByteArray`.
+    fn append_u64(ref self: ByteArray, value: u64);
+    /// Appends a 128-bit unsigned integer to the `ByteArray`.
+    fn append_u128(ref self: ByteArray, value: u128);
+    /// Appends a 256-bit unsigned integer to the `ByteArray`.
+    fn append_u256(ref self: ByteArray, value: u256);
+    /// Appends a `felt252` to the `ByteArray`.
+    fn append_felt252(ref self: ByteArray, value: felt252);
+    /// Appends a Starknet contract address to the `ByteArray`.
+    fn append_address(ref self: ByteArray, value: ContractAddress);
+    /// Appends a `bytes31` value to the `ByteArray`.
+    fn append_bytes31(ref self: ByteArray, value: bytes31);
+    /// Updates a byte at the given `offset` with a new value.
+    fn update_at(ref self: ByteArray, offset: usize, value: u8);
+    fn read_uint_within_size<
+        T, +Add<T>, +Mul<T>, +Zero<T>, +TryInto<felt252, T>, +Drop<T>, +Into<u8, T>,
+    >(
+        self: @ByteArray, offset: usize, size: usize,
+    ) -> (usize, T) {
+        read_uint::<T>(self, offset, size)
+    }
+}
+
+
+impl ByteArrayTraitExtImpl of ByteArrayTraitExt {
+    /// Read a u16 from ByteArray
+    #[inline(always)]
+    fn read_u16(self: @ByteArray, offset: usize) -> (usize, u16) {
+        read_uint::<u16>(self, offset, 2)
+    }
+
+    /// Read a u32 from ByteArray
+    #[inline(always)]
+    fn read_u32(self: @ByteArray, offset: usize) -> (usize, u32) {
+        read_uint::<u32>(self, offset, 4)
+    }
+
+    /// Read a usize from ByteArray
+    #[inline(always)]
+    fn read_usize(self: @ByteArray, offset: usize) -> (usize, usize) {
+        read_uint::<usize>(self, offset, 4)
+    }
+
+    /// Read a u64 from ByteArray
+    #[inline(always)]
+    fn read_u64(self: @ByteArray, offset: usize) -> (usize, u64) {
+        read_uint::<u64>(self, offset, 8)
+    }
+
+    /// Read a u128 from ByteArray
+    #[inline(always)]
+    fn read_u128(self: @ByteArray, offset: usize) -> (usize, u128) {
+        read_uint::<u128>(self, offset, 16)
+    }
+
+    /// Read a u256 from ByteArray
+    #[inline(always)]
+    fn read_u256(self: @ByteArray, offset: usize) -> (usize, u256) {
+        read_uint::<u256>(self, offset, 32)
+    }
+
+    /// Read a felt252 from ByteArray
+    #[inline(always)]
+    fn read_felt252(self: @ByteArray, offset: usize) -> (usize, felt252) {
+        let (new_offset, value) = read_uint::<u256>(self, offset, 32);
+        (new_offset, value.try_into().expect('Couldn\'t convert to felt252'))
+    }
+
+    /// Read a bytes31 from ByteArray
+    #[inline(always)]
+    fn read_bytes31(self: @ByteArray, offset: usize) -> (usize, bytes31) {
+        assert(offset + 31 <= self.len(), 'out of bound');
+
+        let (new_offset, high) = self.read_u128(offset);
+        let (new_offset, low) = self.read_uint_within_size::<u128>(new_offset, 15);
+
+        let low = U128BitShift::shl(low, 8);
+        let mut value: u256 = u256 { high, low };
+        value = U256BitShift::shr(value, 8);
+
+        // Unwrap is always safe here, because highest byte is always 0
+        let value: felt252 = value.try_into().expect('Couldn\'t convert to felt252');
+        let value: bytes31 = value.try_into().expect('Couldn\'t convert to bytes31');
+        (new_offset, value)
+    }
+
+    /// Read Contract Address from Bytes
+    #[inline(always)]
+    fn read_address(self: @ByteArray, offset: usize) -> (usize, ContractAddress) {
+        let (new_offset, value) = self.read_u256(offset);
+        let address: felt252 = value.try_into().expect('Couldn\'t convert to felt252');
+        (new_offset, address.try_into().expect('Couldn\'t convert to address'))
+    }
+
+    /// Read bytes from ByteArray
+    #[inline(always)]
+    fn read_bytes(self: @ByteArray, offset: usize, size: usize) -> (usize, ByteArray) {
+        assert(offset + size <= self.len(), 'out of bound');
+
+        if size == 0 {
+            return (offset, Default::default());
+        }
+
+        let mut ba: ByteArray = Default::default();
+
+        // read full array element for sub_bytes
+        let mut offset = offset;
+        //read per block of u32
+        let mut sub_bytes_full_array_len = size / 4;
+
+        while sub_bytes_full_array_len != 0 {
+            let (new_offset, value) = self.read_u32(offset);
+            ba.append_u32(value);
+            offset = new_offset;
+            sub_bytes_full_array_len -= 1;
+        }
+
+        // process last array element for sub_bytes
+        // 1. read last element real value;
+        // 2. make last element full with padding 0;
+        let mut sub_bytes_last_element_size = size % 4;
+        while sub_bytes_last_element_size != 0 {
+            let value = self.at(offset).unwrap();
+            ba.append_byte(value);
+            sub_bytes_last_element_size -= 1;
+            offset += 1;
+        }
+
+        return (offset, ba);
+    }
+
+    /// Read an array of u128 values from ByteArray
+    fn read_u128_array_packed(
+        self: @ByteArray, offset: usize, array_length: usize, element_size: usize,
+    ) -> (usize, Array<u128>) {
+        assert(offset + array_length * element_size <= self.len(), 'out of bound');
+        let mut array: Array<u128> = array![];
+
+        if array_length == 0 {
+            return (offset, array);
+        }
+        let mut offset = offset;
+        let mut i = array_length;
+        while i != 0 {
+            let (new_offset, value) = self.read_uint_within_size::<u128>(offset, element_size);
+            array.append(value);
+            offset = new_offset;
+            i -= 1;
+        }
+        (offset, array)
+    }
+
+    /// Read an array of u256 values from ByteArray
+    fn read_u256_array(
+        self: @ByteArray, offset: usize, array_length: usize,
+    ) -> (usize, Array<u256>) {
+        assert(offset + array_length * 32 <= self.len(), 'out of bound');
+        let mut array = array![];
+
+        if array_length == 0 {
+            return (offset, array);
+        }
+
+        let mut offset = offset;
+        let mut i = array_length;
+        while i != 0 {
+            let (new_offset, value) = self.read_u256(offset);
+            array.append(value);
+            offset = new_offset;
+            i -= 1;
+        }
+        (offset, array)
+    }
+
+    /// Reads an unsigned integer of type T from the ByteArray starting at a given offset,
+    /// with a specified size.
+    ///
+    /// Inputs:
+    /// - self: A reference to the ByteArray from which to read.
+    /// - offset: The starting position in the ByteArray to begin reading.
+    /// - size: The number of bytes to read.
+    ///
+    /// Outputs:
+    /// - A tuple containing:
+    ///   - The new offset after reading the specified number of bytes.
+    ///   - The value of type T read from the ByteArray.
+    fn read_uint_within_size<
+        T, +Add<T>, +Mul<T>, +Zero<T>, +TryInto<felt252, T>, +Drop<T>, +Into<u8, T>,
+    >(
+        self: @ByteArray, offset: usize, size: usize,
+    ) -> (usize, T) {
+        read_uint::<T>(self, offset, size)
+    }
+
+    /// Append a u16 to ByteArray
+    fn append_u16(ref self: ByteArray, value: u16) {
+        self.append_word(value.into(), 2);
+    }
+
+    /// Append a u32 to ByteArray
+    fn append_u32(ref self: ByteArray, value: u32) {
+        self.append_word(value.into(), 4);
+    }
+
+    /// Append a u64 to ByteArray
+    fn append_u64(ref self: ByteArray, value: u64) {
+        self.append_word(value.into(), 8);
+    }
+
+    /// Append a u128 to ByteArray
+    fn append_u128(ref self: ByteArray, value: u128) {
+        self.append_word(value.into(), 16);
+    }
+
+    /// Append a u256 to ByteArray
+    fn append_u256(ref self: ByteArray, value: u256) {
+        self.append_u128(value.high);
+        self.append_u128(value.low);
+    }
+
+    /// Append a felt252 to ByteArray
+    fn append_felt252(ref self: ByteArray, value: felt252) {
+        let value: u256 = value.into();
+        self.append_u256(value);
+    }
+
+    /// Append a ContractAddress to ByteArray
+    fn append_address(ref self: ByteArray, value: ContractAddress) {
+        let address: felt252 = value.into();
+        self.append_felt252(address);
+    }
+
+    /// Append a bytes31 to ByteArray
+    fn append_bytes31(ref self: ByteArray, value: bytes31) {
+        let mut value: u256 = value.into();
+        value = U256BitShift::shl(value, 8);
+        self.append_u256(value);
+    }
+
+    /// Update a byte at a specific offset in ByteArray
+    fn update_at(ref self: ByteArray, offset: usize, value: u8) {
+        assert(offset <= self.len(), 'out of bound');
+
+        let (_, temp_l) = self.read_bytes(0, offset);
+        let (_, temp_r) = self.read_bytes(offset + 1, self.len() - 1 - offset);
+        let mut new_byte_array: ByteArray = temp_l;
+        new_byte_array.append_byte(value);
+        new_byte_array.append(@temp_r);
+        self = new_byte_array;
+    }
+}
+
+/// Reads an unsigned integer of type T from the ByteArray starting at a given offset,
+/// with a specified size.
+///
+/// Inputs:
+/// - self: A reference to the ByteArray from which to read.
+/// - offset: The starting position in the ByteArray to begin reading.
+/// - size: The number of bytes to read.
+///
+/// Outputs:
+/// - A tuple containing:
+///   - The new offset after reading the specified number of bytes.
+///   - The value of type T read from the ByteArray.
+fn read_uint<T, +Add<T>, +Mul<T>, +Zero<T>, +TryInto<felt252, T>, +Drop<T>, +Into<u8, T>>(
+    self: @ByteArray, offset: usize, mut size: usize,
+) -> (usize, T) {
+    // Uncomment the following line to enforce bounds checking
+    assert(offset + size <= self.len(), 'out of bound');
+
+    // Adjust size if it exceeds the length of the ByteArray
+    if size > self.len() && offset == 0 {
+        size = self.len() - offset;
+    }
+
+    let mut value: T = Zero::zero();
+    let mut i = 0;
+
+    // Read bytes and accumulate the value
+    while i < size {
+        let byte: u8 = self.at(offset + i).unwrap();
+        value = (value * 256.try_into().unwrap()) + byte.into();
+        i += 1;
+    }
+
+    (offset + size, value)
+}

--- a/packages/bytes/src/byte_array_ext.cairo
+++ b/packages/bytes/src/byte_array_ext.cairo
@@ -54,9 +54,7 @@ pub trait ByteArrayTraitExt {
         T, +Add<T>, +Mul<T>, +Zero<T>, +TryInto<felt252, T>, +Drop<T>, +Into<u8, T>,
     >(
         self: @ByteArray, offset: usize, size: usize,
-    ) -> (usize, T) {
-        read_uint::<T>(self, offset, size)
-    }
+    ) -> (usize, T);
 }
 
 
@@ -168,6 +166,7 @@ impl ByteArrayTraitExtImpl of ByteArrayTraitExt {
     }
 
     /// Read an array of u128 values from ByteArray
+    #[inline(always)]
     fn read_u128_array_packed(
         self: @ByteArray, offset: usize, array_length: usize, element_size: usize,
     ) -> (usize, Array<u128>) {
@@ -189,6 +188,7 @@ impl ByteArrayTraitExtImpl of ByteArrayTraitExt {
     }
 
     /// Read an array of u256 values from ByteArray
+    #[inline(always)]
     fn read_u256_array(
         self: @ByteArray, offset: usize, array_length: usize,
     ) -> (usize, Array<u256>) {

--- a/packages/bytes/src/lib.cairo
+++ b/packages/bytes/src/lib.cairo
@@ -1,9 +1,11 @@
+pub mod byte_array_ext;
 pub mod bytes;
 pub mod storage;
 
 #[cfg(test)]
 mod tests;
 pub mod utils;
+
 
 pub use bytes::{Bytes, BytesIndex, BytesTrait};
 pub use storage::BytesStore;

--- a/packages/bytes/src/tests.cairo
+++ b/packages/bytes/src/tests.cairo
@@ -1,2 +1,3 @@
+mod test_byte_array_ext;
 mod test_bytes;
 mod test_bytes_store;

--- a/packages/bytes/src/tests/test_byte_array_ext.cairo
+++ b/packages/bytes/src/tests/test_byte_array_ext.cairo
@@ -1,0 +1,371 @@
+use alexandria_bytes::byte_array_ext::ByteArrayTraitExt;
+
+// Tests for boundary conditions and edge cases
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('out of bound',))]
+fn test_read_from_empty_byte_array() {
+    let ba = Default::default();
+    ba.read_u16(0);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_read_write_max_u16() {
+    let max_u16 = 0xffff_u16;
+    let mut ba = Default::default();
+    ba.append_u16(max_u16);
+    let (new_offset, result) = ba.read_u16(0);
+    assert_eq!(new_offset, 2);
+    assert_eq!(result, max_u16);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_read_write_max_u32() {
+    let max_u32 = 0xffffffff_u32;
+    let mut ba = Default::default();
+    ba.append_u32(max_u32);
+    let (new_offset, result) = ba.read_u32(0);
+    assert_eq!(new_offset, 4);
+    assert_eq!(result, max_u32);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_read_zero_length_u128_array() {
+    let mut ba = Default::default();
+    let (new_offset, result) = ba.read_u128_array_packed(0, 0, 16);
+    assert_eq!(new_offset, 0);
+    assert_eq!(result.len(), 0);
+}
+
+// Tests for appending values
+#[test]
+#[available_gas(20000000)]
+fn test_append_u128() {
+    let mut ba = Default::default();
+    ba.append_u128(0x01020304050607080910111213141516);
+    assert_eq!(ba.len(), 16);
+    assert_eq!(ba.at(0).unwrap(), 0x01);
+    assert_eq!(ba.at(15).unwrap(), 0x16);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_append_u256() {
+    let mut ba = Default::default();
+    ba
+        .append_u256(
+            u256 {
+                high: 0x01020304050607080910111213141516, low: 0x17181920212223242526272829303132,
+            },
+        );
+    assert_eq!(ba.len(), 32);
+    assert_eq!(ba.at(0).unwrap(), 0x01);
+    assert_eq!(ba.at(31).unwrap(), 0x32);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_append_felt252() {
+    let mut ba = Default::default();
+    let felt_value: felt252 = 0x0102030405060708091011121314151617181920212223242526272829303132
+        .try_into()
+        .unwrap();
+    ba.append_felt252(felt_value);
+    assert_eq!(ba.len(), 32);
+    assert_eq!(ba.at(0).unwrap(), 0x01);
+    assert_eq!(ba.at(31).unwrap(), 0x32);
+}
+
+// Tests for reading values
+#[test]
+#[available_gas(20000000)]
+fn test_read_felt252() {
+    let mut ba = Default::default();
+    let felt_value: felt252 = 0x0102030405060708091011121314151617181920212223242526272829303132
+        .try_into()
+        .unwrap();
+    ba.append_felt252(felt_value);
+    let (new_offset, result) = ba.read_felt252(0);
+    assert_eq!(new_offset, 32);
+    assert_eq!(result, felt_value);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_read_u16_at_boundary() {
+    let mut ba = Default::default();
+    ba.append_u32(0x03040506);
+    let (new_offset, result) = ba.read_u16(2);
+    assert_eq!(new_offset, 4);
+    assert_eq!(result, 0x0506);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_append() {
+    let mut ba = Default::default();
+    ba.append_u16(0x0102);
+    assert_eq!(ba.len(), 2);
+    assert_eq!(ba.at(0).unwrap(), 0x01);
+    assert_eq!(ba.at(1).unwrap(), 0x02);
+
+    ba.append_u32(0x03040506);
+    assert_eq!(ba.len(), 6);
+    assert_eq!(ba.at(2).unwrap(), 0x03);
+    assert_eq!(ba.at(5).unwrap(), 0x06);
+
+    ba.append_u64(0x0708091011121314);
+    assert_eq!(ba.len(), 14);
+    assert_eq!(ba.at(6).unwrap(), 0x07);
+    assert_eq!(ba.at(13).unwrap(), 0x14);
+
+    let mut ba2 = Default::default();
+    let address = 0x015401855d7796176b05d160196ff92381eb7910f5446c2e0e04e13db2194a4f
+        .try_into()
+        .unwrap();
+    ba2.append_address(address);
+    assert_eq!(ba2.len(), 32);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_append_byte_31() {
+    let b31: bytes31 = 0x030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f1700
+        .try_into()
+        .unwrap();
+
+    let mut ba = Default::default();
+    ba.append_bytes31(b31);
+    let (offset, val) = ba.read_bytes31(0);
+    assert_eq!(offset, 31, "wrong offset");
+    assert!(val == b31, "append_bytes31 mismatch expected value");
+}
+
+// Tests for reading specific data types
+#[test]
+#[available_gas(20000000)]
+fn test_read_u16() {
+    let mut ba = Default::default();
+    ba.append_u32(0x03040506);
+    let (new_offset, result) = ba.read_u16(1);
+    assert_eq!(new_offset, 3);
+    assert_eq!(result, 0x0405);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_read_u32() {
+    let mut ba = Default::default();
+    ba.append_u32(0x03040506);
+    let (new_offset, result) = ba.read_u32(0);
+    assert_eq!(new_offset, 4);
+    assert_eq!(result, 0x03040506);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_usize() {
+    let mut ba = Default::default();
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910000000000000);
+    let (new_offset, result) = ba.read_usize(15);
+    assert_eq!(new_offset, 19);
+    assert_eq!(result, 0x16010203);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_read_u64() {
+    let mut ba = Default::default();
+    ba.append_u64(0x0708091011121314);
+    let (new_offset, result) = ba.read_u64(0);
+    assert_eq!(new_offset, 8);
+    assert_eq!(result, 0x0708091011121314);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u128() {
+    let mut ba = Default::default();
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910000000000000);
+    let (new_offset, result) = ba.read_u128(15);
+    assert_eq!(new_offset, 31);
+    assert_eq!(result, 0x16010203040506070809101112131415);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u256() {
+    let mut ba = Default::default();
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910000000000000);
+    let (new_offset, result) = ba.read_u256(4);
+    assert_eq!(new_offset, 36);
+    assert_eq!(result.high, 0x05060708091011121314151601020304);
+    assert_eq!(result.low, 0x05060708091011121314151601020304);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_address() {
+    let mut ba = Default::default();
+    ba.append_u128(0x01020304050607080910111213140154);
+    ba.append_u128(0x01855d7796176b05d160196ff92381eb);
+    ba.append_u128(0x7910f5446c2e0e04e13db2194a4f0000);
+
+    let address = 0x015401855d7796176b05d160196ff92381eb7910f5446c2e0e04e13db2194a4f;
+
+    let (new_offset, value) = ba.read_address(14);
+    assert_eq!(new_offset, 46);
+    assert_eq!(value.into(), address);
+}
+
+// Tests for reading bytes
+#[test]
+#[available_gas(20000000)]
+fn test_read_bytes_size_0() {
+    let mut ba = Default::default();
+    let (new_offset, result) = ba.read_bytes(0, 0);
+    assert_eq!(new_offset, 0);
+    assert_eq!(result, Default::default());
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_read_bytes_lower_than_32() {
+    let mut ba = Default::default();
+    let mut expected_result = Default::default();
+    expected_result.append_u16(0x0405);
+    ba.append_u32(0x03040506);
+    let (new_offset, result) = ba.read_bytes(1, 2);
+    assert_eq!(new_offset, 3);
+    assert_eq!(result, expected_result);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_read_bytes_greater_than_32() {
+    let mut ba = Default::default();
+    let mut expected_result = Default::default();
+    expected_result.append_u32(0x08091011);
+    expected_result.append_u16(0x1213);
+    ba.append_u64(0x0708091011121314);
+    let (new_offset, result) = ba.read_bytes(1, 6);
+    assert_eq!(new_offset, 7);
+    assert_eq!(result, expected_result);
+}
+
+// Tests for updating bytes
+#[test]
+#[available_gas(20000000)]
+fn test_update_at() {
+    let mut ba = Default::default();
+    let mut expected_result = Default::default();
+    expected_result.append_u32(0x08071011);
+    ba.append_u32(0x08091011);
+    ba.update_at(1, 0x07);
+    assert_eq!(ba.len(), expected_result.len());
+    assert_eq!(ba, expected_result);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_update_at_first_byte() {
+    let mut ba = Default::default();
+    let mut expected_result = Default::default();
+    expected_result.append_u32(0x07091011);
+    ba.append_u32(0x08091011);
+    ba.update_at(0, 0x07);
+    assert_eq!(ba.len(), expected_result.len());
+    assert_eq!(ba, expected_result);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_update_at_last_byte() {
+    let mut ba = Default::default();
+    let mut expected_result = Default::default();
+    expected_result.append_u32(0x08091007);
+    ba.append_u32(0x08091011);
+    ba.update_at(ba.len() - 1, 0x07);
+    assert_eq!(ba.len(), expected_result.len());
+    assert_eq!(ba, expected_result);
+}
+
+// Tests for reading arrays
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u128_array_packed() {
+    let mut ba = Default::default();
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910000000000000);
+
+    let (new_offset, new_array) = ba.read_u128_array_packed(0, 3, 3);
+    assert_eq!(new_offset, 9);
+    assert_eq!(*new_array[0], 0x010203);
+    assert_eq!(*new_array[1], 0x040506);
+    assert_eq!(*new_array[2], 0x070809);
+
+    let (new_offset, new_array) = ba.read_u128_array_packed(9, 4, 7);
+    assert_eq!(new_offset, 37);
+    assert_eq!(*new_array[0], 0x10111213141516);
+    assert_eq!(*new_array[1], 0x01020304050607);
+    assert_eq!(*new_array[2], 0x08091011121314);
+    assert_eq!(*new_array[3], 0x15160102030405);
+}
+
+#[test]
+#[available_gas(20000000)]
+#[should_panic(expected: ('out of bound',))]
+fn test_bytes_read_u128_array_packed_out_of_bound() {
+    let mut ba = Default::default();
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.read_u128_array_packed(0, 11, 4);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_u256_array() {
+    let mut ba = Default::default();
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x16151413121110090807060504030201);
+    ba.append_u128(0x16151413121110090807060504030201);
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x01020304050607080910111213141516);
+    ba.append_u128(0x16151413121110090000000000000000);
+
+    let (new_offset, new_array) = ba.read_u256_array(7, 2);
+    assert_eq!(new_offset, 71);
+    let result: u256 = *new_array[0];
+    assert_eq!(result.high, 0x08091011121314151616151413121110);
+    assert_eq!(result.low, 0x09080706050403020116151413121110);
+    let result: u256 = *new_array[1];
+    assert_eq!(result.high, 0x09080706050403020101020304050607);
+    assert_eq!(result.low, 0x08091011121314151601020304050607);
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_bytes_read_bytes31() {
+    let mut ba = Default::default();
+    ba.append_u128(0x0102030405060708090a0b0c0d0e0f10);
+    ba.append_u128(0x1112131415161718191a1b1c1d1e1f17);
+    ba.append_u128(0x00);
+
+    let (offset, val) = ba.read_bytes31(2);
+
+    assert_eq!(offset, 33);
+    let byte31: bytes31 = 0x030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f1700
+        .try_into()
+        .unwrap();
+
+    assert!(val == byte31, "read_bytes31 mismatch expected value");
+}


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

Implementation of ByteArrayExt taking over Bytes cairo class in order to deprecate it. Some function can be rework to reduce gas cost once ByteArray prop become public

Implemented Functions in ByteArrayTraitExt

Reading Functions :

    - read_u8
    - read_u16
    - read_u32
    - read_usize
    - read_u64
    - read_u128
    - read_u128_packed
    - read_u256
    - read_u128_array_packed
    - read_u256_array
    - read_felt252
    - read_felt252_packed
    - read_bytes31
    - read_address
    - read_bytes
    - read_uint_within_size

Appending Functions:

    - append_u8
    - append_u16
    - append_u32
    - append_usize
    - append_u64
    - append_u128
    - append_u256
    - append_felt252
    - append_address
    - append_bytes31

Utility Functions:

    - new
    - new_empty
    - size
    - update_at

Missing Functions from Bytes

    - zero --> not needed
    - locate --> can be implemented to reduce gas cost once ByteArray prop will become public
    - data --> can be implemented to reduce gas cost once ByteArray prop will become public
    - append_u128_packed --> not needed because it's not anymore required to add padding 0
    - concat --> use concat from standard impl



## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
