### PR TITLE
 Bytes : auto pad left item is size below 16 bytes

### DIFF
--- a/packages/bytes/src/bytes.cairo
+++ b/packages/bytes/src/bytes.cairo
@@ -1,5 +1,5 @@
 use alexandria_bytes::utils::{
-    keccak_u128s_be, pad_right_data, read_sub_u128, u128_array_slice, u128_join, u128_split,
+    keccak_u128s_be, pad_left_data, read_sub_u128, u128_array_slice, u128_join, u128_split,
     u32s_to_u256,
 };
 use alexandria_math::{U128BitShift, U256BitShift};
@@ -138,7 +138,7 @@ pub trait BytesTrait {
 impl BytesImpl of BytesTrait {
     #[inline(always)]
     fn new(size: usize, data: Array<u128>) -> Bytes {
-        Bytes { size, data: pad_right_data(data, BYTES_PER_ELEMENT) }
+        Bytes { size, data: pad_left_data(data, BYTES_PER_ELEMENT) }
     }
 
     #[inline(always)]
@@ -610,7 +610,7 @@ impl BytesSerde of Serde<Bytes> {
     fn deserialize(ref serialized: Span<felt252>) -> Option<Bytes> {
         let size = Serde::<usize>::deserialize(ref serialized)?;
         let data = Serde::<Array<u128>>::deserialize(ref serialized)?;
-        Option::Some(Bytes { size, data: pad_right_data(data, BYTES_PER_ELEMENT) })
+        Option::Some(Bytes { size, data: pad_left_data(data, BYTES_PER_ELEMENT) })
     }
 }
 

--- a/packages/bytes/src/bytes.cairo
+++ b/packages/bytes/src/bytes.cairo
@@ -50,74 +50,222 @@ pub impl BytesIndex of IndexView<Bytes, usize> {
 
 pub trait BytesTrait {
     /// Create a Bytes from an array of u128
+    #[deprecated(
+        feature: "deprecated-new",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::new`.",
+        since: "2.11.1",
+    )]
     fn new(size: usize, data: Array<u128>) -> Bytes;
     /// Create an empty Bytes
+    #[deprecated(
+        feature: "deprecated-new_empty",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::new_empty`.",
+        since: "2.11.1",
+    )]
     fn new_empty() -> Bytes;
     /// Create a Bytes with size bytes 0
     fn zero(size: usize) -> Bytes;
     /// Locate offset in Bytes
     fn locate(offset: usize) -> (usize, usize);
     /// Get Bytes size
+    #[deprecated(
+        feature: "deprecated-size",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::size`.",
+        since: "2.11.1",
+    )]
     fn size(self: @Bytes) -> usize;
     /// Get data
     fn data(self: Bytes) -> Array<u128>;
     /// update specific value (1 bytes) at specific offset
+    #[deprecated(
+        feature: "deprecated-size",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::size`.",
+        since: "2.11.1",
+    )]
     fn update_at(ref self: Bytes, offset: usize, value: u8);
     /// Read value with size bytes from Bytes, and packed into u128
+    #[deprecated(
+        feature: "deprecated-read_u128_packed",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u128_packed`.",
+        since: "2.11.1",
+    )]
     fn read_u128_packed(self: @Bytes, offset: usize, size: usize) -> (usize, u128);
     /// Read value with element_size bytes from Bytes, and packed into u128 array
+    #[deprecated(
+        feature: "deprecated-read_u128_array_packed",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u128_array_packed`.",
+        since: "2.11.1",
+    )]
     fn read_u128_array_packed(
         self: @Bytes, offset: usize, array_length: usize, element_size: usize,
     ) -> (usize, Array<u128>);
     /// Read value with size bytes from Bytes, and packed into felt252
+    #[deprecated(
+        feature: "deprecated-read_felt252_packed",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_felt252_packed`.",
+        since: "2.11.1",
+    )]
     fn read_felt252_packed(self: @Bytes, offset: usize, size: usize) -> (usize, felt252);
     /// Read a u8 from Bytes
+    #[deprecated(
+        feature: "deprecated-read_u8",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u8`.",
+        since: "2.11.1",
+    )]
     fn read_u8(self: @Bytes, offset: usize) -> (usize, u8);
     /// Read a u16 from Bytes
+    #[deprecated(
+        feature: "deprecated-read_u16",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u16`.",
+        since: "2.11.1",
+    )]
     fn read_u16(self: @Bytes, offset: usize) -> (usize, u16);
     /// Read a u32 from Bytes
+    #[deprecated(
+        feature: "deprecated-read_u32",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u32`.",
+        since: "2.11.1",
+    )]
     fn read_u32(self: @Bytes, offset: usize) -> (usize, u32);
     /// Read a usize from Bytes
+    #[deprecated(
+        feature: "deprecated-read_usize",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_usize`.",
+        since: "2.11.1",
+    )]
     fn read_usize(self: @Bytes, offset: usize) -> (usize, usize);
     /// Read a u64 from Bytes
+    #[deprecated(
+        feature: "deprecated-read_u64",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u64`.",
+        since: "2.11.1",
+    )]
     fn read_u64(self: @Bytes, offset: usize) -> (usize, u64);
     /// Read a u128 from Bytes
+    #[deprecated(
+        feature: "deprecated-read_u128",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u128`.",
+        since: "2.11.1",
+    )]
     fn read_u128(self: @Bytes, offset: usize) -> (usize, u128);
     /// Read a u256 from Bytes
+    #[deprecated(
+        feature: "deprecated-read_u256",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u256`.",
+        since: "2.11.1",
+    )]
     fn read_u256(self: @Bytes, offset: usize) -> (usize, u256);
     /// Read a u256 array from Bytes
+    #[deprecated(
+        feature: "deprecated-read_u256_array",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_u256_array`.",
+        since: "2.11.1",
+    )]
     fn read_u256_array(self: @Bytes, offset: usize, array_length: usize) -> (usize, Array<u256>);
     /// Read sub Bytes with size bytes from Bytes
+    #[deprecated(
+        feature: "deprecated-read_bytes",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_bytes`.",
+        since: "2.11.1",
+    )]
     fn read_bytes(self: @Bytes, offset: usize, size: usize) -> (usize, Bytes);
     /// Read felt252 from Bytes, which stored as u256
+    #[deprecated(
+        feature: "deprecated-read_felt252",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_felt252`.",
+        since: "2.11.1",
+    )]
     fn read_felt252(self: @Bytes, offset: usize) -> (usize, felt252);
     /// Read bytes31 from Bytes
+    #[deprecated(
+        feature: "deprecated-read_bytes31",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_bytes31`.",
+        since: "2.11.1",
+    )]
     fn read_bytes31(self: @Bytes, offset: usize) -> (usize, bytes31);
     /// Read a ContractAddress from Bytes
+    #[deprecated(
+        feature: "deprecated-read_address",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::read_address`.",
+        since: "2.11.1",
+    )]
     fn read_address(self: @Bytes, offset: usize) -> (usize, ContractAddress);
     /// Write value with size bytes into Bytes, value is packed into u128
     fn append_u128_packed(ref self: Bytes, value: u128, size: usize);
     /// Write u8 into Bytes
+    #[deprecated(
+        feature: "deprecated-append_u8",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_u8`.",
+        since: "2.11.1",
+    )]
     fn append_u8(ref self: Bytes, value: u8);
     /// Write u16 into Bytes
+    #[deprecated(
+        feature: "deprecated-append_u16",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_u16`.",
+        since: "2.11.1",
+    )]
     fn append_u16(ref self: Bytes, value: u16);
     /// Write u32 into Bytes
+    #[deprecated(
+        feature: "deprecated-append_u32",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_u32`.",
+        since: "2.11.1",
+    )]
     fn append_u32(ref self: Bytes, value: u32);
     /// Write usize into Bytes
+    #[deprecated(
+        feature: "deprecated-append_usize",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_usize`.",
+        since: "2.11.1",
+    )]
     fn append_usize(ref self: Bytes, value: usize);
     /// Write u64 into Bytes
+    #[deprecated(
+        feature: "deprecated-append_u64",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_u64`.",
+        since: "2.11.1",
+    )]
     fn append_u64(ref self: Bytes, value: u64);
     /// Write u128 into Bytes
+    #[deprecated(
+        feature: "deprecated-append_u128",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_u128`.",
+        since: "2.11.1",
+    )]
     fn append_u128(ref self: Bytes, value: u128);
     /// Write u256 into Bytes
+    #[deprecated(
+        feature: "deprecated-append_u256",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_u256`.",
+        since: "2.11.1",
+    )]
     fn append_u256(ref self: Bytes, value: u256);
     /// Write felt252 into Bytes, which stored as u256
+    #[deprecated(
+        feature: "deprecated-append_felt252",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_felt252`.",
+        since: "2.11.1",
+    )]
     fn append_felt252(ref self: Bytes, value: felt252);
     /// Write bytes31 into Bytes
+    #[deprecated(
+        feature: "deprecated-append_bytes31",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_bytes31`.",
+        since: "2.11.1",
+    )]
     fn append_bytes31(ref self: Bytes, value: bytes31);
     /// Write address into Bytes
+    #[deprecated(
+        feature: "deprecated-append_address",
+        note: "Use `alexandria_bytes::byte_array_ext::ByteArrayTraitExt::append_address`.",
+        since: "2.11.1",
+    )]
     fn append_address(ref self: Bytes, value: ContractAddress);
     /// concat with other Bytes
+    #[deprecated(
+        feature: "deprecated-concat", note: "Use `core::byte_array::concat`.", since: "2.11.1",
+    )]
     fn concat(ref self: Bytes, other: @Bytes);
     /// keccak hash
     #[deprecated(

--- a/packages/bytes/src/bytes.cairo
+++ b/packages/bytes/src/bytes.cairo
@@ -51,7 +51,7 @@ pub impl BytesIndex of IndexView<Bytes, usize> {
 pub trait BytesTrait {
     /// Create a Bytes from an array of u128
     fn new(size: usize, data: Array<u128>) -> Bytes;
-    /// Create an empty Bytes²
+    /// Create an empty Bytes
     fn new_empty() -> Bytes;
     /// Create a Bytes with size bytes 0
     fn zero(size: usize) -> Bytes;

--- a/packages/bytes/src/tests/test_bytes.cairo
+++ b/packages/bytes/src/tests/test_bytes.cairo
@@ -1013,3 +1013,21 @@ fn test_serde_deser_compare_bytes() {
     assert!(deser.data() == bytes2.data(), "expected equal data");
 }
 
+#[test]
+#[available_gas(20000000)]
+#[should_panic()]
+fn test_deser_exceed_u128() {
+    let expected_array: Array<felt252> = array![
+        80,
+        5,
+        0x0102030405060708091011121314151617,
+        0x0123,
+        0x1234,
+        0x012345,
+        0x01020304050607080910111213141516,
+    ];
+
+    let mut span = expected_array.span();
+    Serde::<Bytes>::deserialize(ref span).unwrap();
+}
+

--- a/packages/bytes/src/tests/test_bytes.cairo
+++ b/packages/bytes/src/tests/test_bytes.cairo
@@ -827,7 +827,7 @@ fn test_serde_with_first_padded() {
 #[available_gas(20000000)]
 fn test_serde_with_last_padded() {
     let mut out = array![];
-    let mut array = array![0x01020304050607080910111213141516,0x010203040506];
+    let mut array = array![0x01020304050607080910111213141516, 0x010203040506];
 
     let bytes = BytesTrait::new(22, array);
 
@@ -937,7 +937,7 @@ fn test_serde_deser_last_not_padded() {
         0x0123,
         0x01234,
         0x012345,
-        0x01020304050607080910111213141516
+        0x01020304050607080910111213141516,
     ];
     let bytes = BytesTrait::new(80, array);
     bytes.serialize(ref out);

--- a/packages/bytes/src/tests/test_bytes.cairo
+++ b/packages/bytes/src/tests/test_bytes.cairo
@@ -623,6 +623,7 @@ fn test_bytes_keccak() {
     assert_eq!(res, hash);
 
     // u256{low: 1, high: 0}
+    //0x0000000000000000000000000000000000000000000000000000000000000001
     let mut array = array![];
     array.append(0);
     array.append(1);
@@ -712,7 +713,7 @@ fn test_bytes_new_with_padded_first() {
 
     let (new_offset, value) = bytes.read_u128(0);
     assert_eq!(new_offset, 16);
-    assert_eq!(value, 0x01230000000000000000000000000000);
+    assert_eq!(value, 0x00000000000000000000000000000123);
 }
 
 #[test]
@@ -726,7 +727,7 @@ fn test_bytes_new_with_padded_mid() {
 
     let (new_offset, value) = bytes.read_u128(16);
     assert_eq!(new_offset, 32);
-    assert_eq!(value, 0x01230000000000000000000000000000);
+    assert_eq!(value, 0x00000000000000000000000000000123);
 }
 
 #[test]
@@ -740,7 +741,7 @@ fn test_bytes_new_with_padded_last() {
 
     let (new_offset, value) = bytes.read_u128_packed(32, 16);
     assert_eq!(new_offset, 48);
-    assert_eq!(value, 0x01230000000000000000000000000000);
+    assert_eq!(value, 0x00000000000000000000000000000123);
 }
 
 #[test]
@@ -758,7 +759,7 @@ fn test_bytes_new_with_padded_multi() {
 
     let (new_offset, value) = bytes.read_u128_packed(16, 16);
     assert_eq!(new_offset, 32);
-    assert_eq!(value, 0x01230000000000000000000000000000);
+    assert_eq!(value, 0x00000000000000000000000000000123);
 
     let (new_offset, value) = bytes.read_u128_packed(32, 16);
     assert_eq!(new_offset, 48);
@@ -766,11 +767,11 @@ fn test_bytes_new_with_padded_multi() {
 
     let (new_offset, value) = bytes.read_u128(48);
     assert_eq!(new_offset, 64);
-    assert_eq!(value, 0x12340000000000000000000000000000);
+    assert_eq!(value, 0x00000000000000000000000000001234);
 
     let (new_offset, value) = bytes.read_u128_packed(64, 16);
     assert_eq!(new_offset, 80);
-    assert_eq!(value, 0x12345000000000000000000000000000);
+    assert_eq!(value, 0x00000000000000000000000000123450);
 }
 
 #[test]
@@ -791,15 +792,15 @@ fn test_serde() {
 
     let array_1_pos: felt252 = out.pop_front().unwrap();
     let array_1_pos: u128 = array_1_pos.try_into().unwrap();
-    assert!(array_1_pos == 0x01000000000000000000000000000000, "expected same u128 at pos 1");
+    assert!(array_1_pos == 0x00000000000000000000000000000001, "expected same u128 at pos 1");
 
     let array_2_pos: felt252 = out.pop_front().unwrap();
     let array_2_pos: u128 = array_2_pos.try_into().unwrap();
-    assert!(array_2_pos == 0x02000000000000000000000000000000, "expected same u128 at pos 2");
+    assert!(array_2_pos == 0x00000000000000000000000000000002, "expected same u128 at pos 2");
 
     let array_3_pos: felt252 = out.pop_front().unwrap();
     let array_3_pos: u128 = array_3_pos.try_into().unwrap();
-    assert!(array_3_pos == 0x03000000000000000000000000000000, "expected same u128 at pos 3");
+    assert!(array_3_pos == 0x00000000000000000000000000000003, "expected same u128 at pos 3");
 }
 
 #[test]
@@ -820,7 +821,7 @@ fn test_serde_with_first_padded() {
 
     let array_1_pos: felt252 = out.pop_front().unwrap();
     let array_1_pos: u128 = array_1_pos.try_into().unwrap();
-    assert!(array_1_pos == 0x01020304050607000000000000000000, "expected same u128 at pos 1");
+    assert!(array_1_pos == 0x00000000000000000001020304050607, "expected same u128 at pos 1");
 
     let array_2_pos: felt252 = out.pop_front().unwrap();
     let array_2_pos: u128 = array_2_pos.try_into().unwrap();
@@ -849,7 +850,7 @@ fn test_serde_with_last_padded() {
 
     let array_2_pos: felt252 = out.pop_front().unwrap();
     let array_2_pos: u128 = array_2_pos.try_into().unwrap();
-    assert!(array_2_pos == 0x01020304050600000000000000000000, "expected same u128 at pos 2");
+    assert!(array_2_pos == 0x00000000000000000000010203040506, "expected same u128 at pos 2");
 }
 
 #[test]
@@ -880,7 +881,7 @@ fn test_serde_with_multi_padded() {
 
     let array_2_pos: felt252 = out.pop_front().unwrap();
     let array_2_pos: u128 = array_2_pos.try_into().unwrap();
-    assert!(array_2_pos == 0x01230000000000000000000000000000, "expected same u128 at pos 2");
+    assert!(array_2_pos == 0x00000000000000000000000000000123, "expected same u128 at pos 2");
 
     let array_3_pos: felt252 = out.pop_front().unwrap();
     let array_3_pos: u128 = array_3_pos.try_into().unwrap();
@@ -888,11 +889,11 @@ fn test_serde_with_multi_padded() {
 
     let array_4_pos: felt252 = out.pop_front().unwrap();
     let array_4_pos: u128 = array_4_pos.try_into().unwrap();
-    assert!(array_4_pos == 0x01000000000000000000000000000000, "expected same u128 at pos 4");
+    assert!(array_4_pos == 0x00000000000000000000000000000001, "expected same u128 at pos 4");
 
     let array_5_pos: felt252 = out.pop_front().unwrap();
     let array_5_pos: u128 = array_5_pos.try_into().unwrap();
-    assert!(array_5_pos == 0x01234500000000000000000000000000, "expected same u128 at pos 5");
+    assert!(array_5_pos == 0x00000000000000000000000000012345, "expected same u128 at pos 5");
 }
 
 #[test]
@@ -902,9 +903,9 @@ fn test_serde_deser() {
 
     let array = array![0x01, 0x02, 0x03];
     let expected_array = array![
-        0x01000000000000000000000000000000,
-        0x02000000000000000000000000000000,
-        0x03000000000000000000000000000000,
+        0x00000000000000000000000000000001,
+        0x00000000000000000000000000000002,
+        0x00000000000000000000000000000003,
     ];
     let mut bytes = BytesTrait::new(16, array);
     bytes.serialize(ref out);
@@ -931,10 +932,10 @@ fn test_serde_deser_multi_padded() {
 
     let expected_array = array![
         0x01020304050607080910111213141516,
-        0x01230000000000000000000000000000,
+        0x00000000000000000000000000000123,
         0x01020304050607080910111213141516,
-        0x12340000000000000000000000000000,
-        0x01234500000000000000000000000000,
+        0x00000000000000000000000000001234,
+        0x00000000000000000000000000012345,
     ];
 
     let bytes = BytesTrait::new(80, array);
@@ -961,9 +962,9 @@ fn test_serde_deser_last_not_padded() {
 
     let expected_array = array![
         0x01020304050607080910111213141516,
-        0x01230000000000000000000000000000,
-        0x12340000000000000000000000000000,
-        0x01234500000000000000000000000000,
+        0x00000000000000000000000000000123,
+        0x00000000000000000000000000001234,
+        0x00000000000000000000000000012345,
         0x01020304050607080910111213141516,
     ];
 

--- a/packages/bytes/src/tests/test_bytes.cairo
+++ b/packages/bytes/src/tests/test_bytes.cairo
@@ -800,10 +800,146 @@ fn test_serde() {
 
 #[test]
 #[available_gas(20000000)]
+fn test_serde_with_first_padded() {
+    let mut out = array![];
+    let mut array = array![0x01020304050607, 0x01020304050607080910111213141516];
+
+    let bytes = BytesTrait::new(23, array);
+
+    bytes.serialize(ref out);
+
+    assert!(out.pop_front().unwrap().try_into().unwrap() == bytes.size(), "expected equal size");
+
+    let array_size: felt252 = out.pop_front().unwrap();
+    let array_size: u32 = array_size.try_into().unwrap();
+    assert!(array_size == 2, "expected array equal size");
+
+    let array_1_pos: felt252 = out.pop_front().unwrap();
+    let array_1_pos: u128 = array_1_pos.try_into().unwrap();
+    assert!(array_1_pos == 0x01020304050607, "expected same u128 at pos 1");
+
+    let array_2_pos: felt252 = out.pop_front().unwrap();
+    let array_2_pos: u128 = array_2_pos.try_into().unwrap();
+    assert!(array_2_pos == 0x01020304050607080910111213141516, "expected same u128 at pos 2");
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_serde_with_last_padded() {
+    let mut out = array![];
+    let mut array = array![0x01020304050607080910111213141516,0x010203040506];
+
+    let bytes = BytesTrait::new(22, array);
+
+    bytes.serialize(ref out);
+
+    assert!(out.pop_front().unwrap().try_into().unwrap() == bytes.size(), "expected equal size");
+
+    let array_size: felt252 = out.pop_front().unwrap();
+    let array_size: u32 = array_size.try_into().unwrap();
+    assert!(array_size == 2, "expected array equal size");
+
+    let array_1_pos: felt252 = out.pop_front().unwrap();
+    let array_1_pos: u128 = array_1_pos.try_into().unwrap();
+    assert!(array_1_pos == 0x01020304050607080910111213141516, "expected same u128 at pos 1");
+
+    let array_2_pos: felt252 = out.pop_front().unwrap();
+    let array_2_pos: u128 = array_2_pos.try_into().unwrap();
+    assert!(array_2_pos == 0x010203040506, "expected same u128 at pos 2");
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_serde_with_multi_padded() {
+    let mut out = array![];
+    let mut array = array![
+        0x01020304050607080910111213141516,
+        0x0123,
+        0x01020304050607080910111213141516,
+        0x01234,
+        0x012345,
+    ];
+
+    let bytes = BytesTrait::new(80, array);
+
+    bytes.serialize(ref out);
+
+    assert!(out.pop_front().unwrap().try_into().unwrap() == bytes.size(), "expected equal size");
+
+    let array_size: felt252 = out.pop_front().unwrap();
+    let array_size: u32 = array_size.try_into().unwrap();
+    assert!(array_size == 5, "expected array equal size");
+
+    let array_1_pos: felt252 = out.pop_front().unwrap();
+    let array_1_pos: u128 = array_1_pos.try_into().unwrap();
+    assert!(array_1_pos == 0x01020304050607080910111213141516, "expected same u128 at pos 1");
+
+    let array_2_pos: felt252 = out.pop_front().unwrap();
+    let array_2_pos: u128 = array_2_pos.try_into().unwrap();
+    assert!(array_2_pos == 0x0123, "expected same u128 at pos 2");
+
+    let array_3_pos: felt252 = out.pop_front().unwrap();
+    let array_3_pos: u128 = array_3_pos.try_into().unwrap();
+    assert!(array_3_pos == 0x01020304050607080910111213141516, "expected same u128 at pos 3");
+
+    let array_4_pos: felt252 = out.pop_front().unwrap();
+    let array_4_pos: u128 = array_4_pos.try_into().unwrap();
+    assert!(array_4_pos == 0x01234, "expected same u128 at pos 4");
+
+    let array_5_pos: felt252 = out.pop_front().unwrap();
+    let array_5_pos: u128 = array_5_pos.try_into().unwrap();
+    assert!(array_5_pos == 0x012345, "expected same u128 at pos 5");
+}
+
+#[test]
+#[available_gas(20000000)]
 fn test_serde_deser() {
     let mut out = array![];
     let array = array![0x01, 0x02, 0x03];
     let bytes = BytesTrait::new(16, array);
+    bytes.serialize(ref out);
+
+    let mut span = out.span();
+
+    let mut deser = Serde::<Bytes>::deserialize(ref span).unwrap();
+    assert!(deser.size() == bytes.size(), "expected equal lengths");
+    assert!(deser.data() == bytes.data(), "expected equal data");
+}
+
+
+#[test]
+#[available_gas(20000000)]
+fn test_serde_deser_multi_padded() {
+    let mut out = array![];
+    let array = array![
+        0x01020304050607080910111213141516,
+        0x0123,
+        0x01020304050607080910111213141516,
+        0x01234,
+        0x012345,
+    ];
+    let bytes = BytesTrait::new(80, array);
+    bytes.serialize(ref out);
+
+    let mut span = out.span();
+
+    let mut deser = Serde::<Bytes>::deserialize(ref span).unwrap();
+    assert!(deser.size() == bytes.size(), "expected equal lengths");
+    assert!(deser.data() == bytes.data(), "expected equal data");
+}
+
+#[test]
+#[available_gas(20000000)]
+fn test_serde_deser_last_not_padded() {
+    let mut out = array![];
+    let array = array![
+        0x01020304050607080910111213141516,
+        0x0123,
+        0x01234,
+        0x012345,
+        0x01020304050607080910111213141516
+    ];
+    let bytes = BytesTrait::new(80, array);
     bytes.serialize(ref out);
 
     let mut span = out.span();

--- a/packages/bytes/src/utils.cairo
+++ b/packages/bytes/src/utils.cairo
@@ -260,7 +260,7 @@ pub fn u128_join(left: u128, right: u128, right_size: usize) -> u128 {
 /// Return the bytes len represent in u128
 /// Examples:
 /// u128_bytes_len(0x0102) -> 2
-fn u128_bytes_len(value: u128) -> usize {
+pub fn u128_bytes_len(value: u128) -> usize {
     if value <= 0xff_u128 {
         1_usize
     } else if value <= 0xffff_u128 {

--- a/packages/bytes/src/utils.cairo
+++ b/packages/bytes/src/utils.cairo
@@ -295,3 +295,32 @@ pub fn u128_bytes_len(value: u128) -> usize {
         16_usize
     }
 }
+
+/// Pads each `u128` value in the given array with zeros on the right if its byte size is smaller
+/// than `bytes_per_element`.
+///
+/// # Arguments
+/// * `data` - An array of `u128` values that may require padding.
+/// * `bytes_per_element` - The target byte size for each element in the array.
+///
+/// # Returns
+/// * A new `Array<u128>` where each element is either unchanged (if already `bytes_per_element`
+/// bytes) or padded with zeros.
+///
+/// # Padding Strategy
+/// If the byte size of `value` is less than `bytes_per_element`, zeros are added to the right using
+/// `u128_join`.
+pub fn pad_right_data(data: Array<u128>, bytes_per_element: usize) -> Array<u128> {
+    let mut padded_data = array![];
+    for value in data {
+        let value_size = u128_bytes_len(value);
+        let padded_value = if value_size < bytes_per_element {
+            u128_join(value, 0, bytes_per_element - value_size)
+        } else {
+            value
+        };
+        padded_data.append(padded_value);
+    }
+    padded_data
+}
+

--- a/packages/bytes/src/utils.cairo
+++ b/packages/bytes/src/utils.cairo
@@ -296,7 +296,7 @@ pub fn u128_bytes_len(value: u128) -> usize {
     }
 }
 
-/// Pads each `u128` value in the given array with zeros on the right if its byte size is smaller
+/// Pads each `u128` value in the given array with zeros on the left if its byte size is smaller
 /// than `bytes_per_element`.
 ///
 /// # Arguments
@@ -308,14 +308,14 @@ pub fn u128_bytes_len(value: u128) -> usize {
 /// bytes) or padded with zeros.
 ///
 /// # Padding Strategy
-/// If the byte size of `value` is less than `bytes_per_element`, zeros are added to the right using
+/// If the byte size of `value` is less than `bytes_per_element`, zeros are added to the left using
 /// `u128_join`.
-pub fn pad_right_data(data: Array<u128>, bytes_per_element: usize) -> Array<u128> {
+pub fn pad_left_data(data: Array<u128>, bytes_per_element: usize) -> Array<u128> {
     let mut padded_data = array![];
     for value in data {
         let value_size = u128_bytes_len(value);
         let padded_value = if value_size < bytes_per_element {
-            u128_join(value, 0, bytes_per_element - value_size)
+            u128_join(0, value, bytes_per_element - value_size)
         } else {
             value
         };

--- a/packages/bytes/src/utils.cairo
+++ b/packages/bytes/src/utils.cairo
@@ -260,7 +260,7 @@ pub fn u128_join(left: u128, right: u128, right_size: usize) -> u128 {
 /// Return the bytes len represent in u128
 /// Examples:
 /// u128_bytes_len(0x0102) -> 2
-pub fn u128_bytes_len(value: u128) -> usize {
+fn u128_bytes_len(value: u128) -> usize {
     if value <= 0xff_u128 {
         1_usize
     } else if value <= 0xffff_u128 {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Auto pad left when calling Bytes::new when item is < 16 bytes

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
